### PR TITLE
docs: add tor cli doc

### DIFF
--- a/app/src/cli.rs
+++ b/app/src/cli.rs
@@ -8,6 +8,7 @@ pub fn init() -> Cli {
 #[clap(author, version, about, long_about = None)]
 #[clap(propagate_version = true)]
 pub struct Cli {
+    /// Use a local instance of Tor instead of starting one. Tari usually uses 9051
     #[clap(short = 't', long, alias = "local-tor-port")]
     pub local_tor_control_port: Option<u16>,
 }


### PR DESCRIPTION
The intention here is to document the default setting of 9051 that people running Tari would have. I don't know if it's the best way to do it? 