### PR TITLE
[WIP] feature: add arm64 builds

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -44,7 +44,7 @@ jobs:
           os: ubuntu-latest
           rust: stable
           target: aarch64-unknown-linux-gnu
-          cross: true
+          cross: false
         - build: macos-x86_64
           os: macos-latest
           rust: stable
@@ -81,7 +81,6 @@ jobs:
           components: rustfmt, clippy
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
-#          use-cross: ${{ matrix.cross }}
           override: true
 
       - name: Install Linux dependencies - Ubuntu

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -25,41 +25,45 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
-#        os: [ubuntu-18.04, macos-10.15, windows-2019]
-        # https://doc.rust-lang.org/rustc/platform-support.html
-#        target: [ aarch64-apple-darwin, x86_64-apple-darwin ]
-        # https://github.com/lotabout/skim/blob/master/.github/workflows/publish-github.yml
-
-#        build: [ linux-x86_64, linux-arm64, macos-x86_64, macos-arm64, windows-x64 ]
-        build: [ linux-x86_64, linux-arm64 ]
-
+        build:
+          [
+            linux-x86_64, linux-arm64,
+            macos-x86_64, macos-arm64,
+            windows-x64, windows-arm64,
+          ]
         include:
-        - build: linux-x86_64
-          os: ubuntu-latest
-          rust: stable
-          target: x86_64-unknown-linux-gnu
-          cross: false
-        - build: linux-arm64
-          os: ubuntu-latest
-          rust: stable
-          target: aarch64-unknown-linux-gnu
-          cross: false
-        - build: macos-x86_64
-          os: macos-latest
-          rust: stable
-          target: x86_64-apple-darwin
-          cross: false
-        - build: macos-arm64
-          os: macos-latest
-          rust: stable
-          target: aarch64-apple-darwin
-          cross: true
-        - build: windows-x64
-          os: windows-latest
-          rust: stable
-          target: x86_64-pc-windows-msvc
-          cross: false
+          - build: linux-x86_64
+            os: ubuntu-latest
+            rust: stable
+            target: x86_64-unknown-linux-gnu
+            cross: false
+          - build: linux-arm64
+            os: ubuntu-latest
+            rust: stable
+            target: aarch64-unknown-linux-gnu
+            cross: false
+          - build: macos-x86_64
+            os: macos-latest
+            rust: stable
+            target: x86_64-apple-darwin
+            cross: false
+          - build: macos-arm64
+            os: macos-latest
+            rust: stable
+            target: aarch64-apple-darwin
+            cross: false
+          - build: windows-x64
+            os: windows-latest
+            rust: stable
+            target: x86_64-pc-windows-msvc
+            cross: false
+          - build: windows-arm64
+            os: windows-latest
+            rust: stable
+            target: aarch64-pc-windows-msvc
+            cross: false
+        exclude:
+          - build: [linux-arm64]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -93,6 +93,7 @@ jobs:
             pkg-config \
             libsqlite3-dev \
             libasound-dev \
+            librust-alsa-sys-dev \
             libxcb-shape0-dev \
             libxcb-xfixes0-dev \
             libxkbcommon-dev

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -63,7 +63,7 @@ jobs:
             target: aarch64-pc-windows-msvc
             cross: false
         exclude:
-          - build: [linux-arm64]
+          - build: [ linux-arm64, windows-arm64, ]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -31,7 +31,8 @@ jobs:
 #        target: [ aarch64-apple-darwin, x86_64-apple-darwin ]
         # https://github.com/lotabout/skim/blob/master/.github/workflows/publish-github.yml
 
-        build: [ linux-x86_64, linux-arm64, macos-x86_64, macos-arm64, windows-x64 ]
+#        build: [ linux-x86_64, linux-arm64, macos-x86_64, macos-arm64, windows-x64 ]
+        build: [ linux-x86_64, linux-arm64 ]
 
         include:
         - build: linux-x86_64

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ members = [
 ]
 
 [patch.crates-io]
-liblmdb-sys = { git = "https://github.com/leet4tari/lmdb-rs.git" }
+liblmdb-sys = { git = "https://github.com/leet4tari/lmdb-rs.git", branch = "v0.2.3" }

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,8 +1,0 @@
-[build]
-build-std = false                              # do not build the std library. has precedence over xargo
-xargo = true                                   # enable the use of xargo by default
-default-target = "x86_64-unknown-linux-gnu"    # use this target if none is explicitly provided
-pre-build = [                                  # additional commands to run prior to building the package
-  "dpkg --add-architecture $CROSS_DEB_ARCH",
-  "apt-get update && apt-get --assume-yes install libssl-dev:$CROSS_DEB_ARCH alsa-sys:$CROSS_DEB_ARCH openssl:$CROSS_DEB_ARCH libssl-dev:$CROSS_DEB_ARCH pkg-config:$CROSS_DEB_ARCH libsqlite3-dev:$CROSS_DEB_ARCH libasound-dev:$CROSS_DEB_ARCH librust-alsa-sys-dev:$CROSS_DEB_ARCH libxcb-shape0-dev:$CROSS_DEB_ARCH libxcb-xfixes0-dev:$CROSS_DEB_ARCH libxkbcommon-dev:$CROSS_DEB_ARCH"
-]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,8 @@
+[build]
+build-std = false                              # do not build the std library. has precedence over xargo
+xargo = true                                   # enable the use of xargo by default
+default-target = "x86_64-unknown-linux-gnu"    # use this target if none is explicitly provided
+pre-build = [                                  # additional commands to run prior to building the package
+  "dpkg --add-architecture $CROSS_DEB_ARCH",
+  "apt-get update && apt-get --assume-yes install libssl-dev:$CROSS_DEB_ARCH alsa-sys:$CROSS_DEB_ARCH openssl:$CROSS_DEB_ARCH libssl-dev:$CROSS_DEB_ARCH pkg-config:$CROSS_DEB_ARCH libsqlite3-dev:$CROSS_DEB_ARCH libasound-dev:$CROSS_DEB_ARCH librust-alsa-sys-dev:$CROSS_DEB_ARCH libxcb-shape0-dev:$CROSS_DEB_ARCH libxcb-xfixes0-dev:$CROSS_DEB_ARCH libxkbcommon-dev:$CROSS_DEB_ARCH"
+]


### PR DESCRIPTION
OSX ARM64 build

Linux ARM64 does not build. Tried cross-rs, but base image too old

Windows ARM64 - Rust support not so good

Exclude does not work as I want, think we might just comment out the unsupported builds?